### PR TITLE
INPUT lenght BUGFIX

### DIFF
--- a/src/internal/provision_html.h
+++ b/src/internal/provision_html.h
@@ -668,8 +668,9 @@ static constexpr const char index_html13[] PROGMEM =
               if (!code_listener.value) {
                 return `${input_name_text} is required`;
               }
-              if (code_listener.value.length !== input_lenght) {
-                return `${input_name_text} should be ${input_lenght} characters long`;
+              if (code_listener.value.length > input_lenght) {
+                return `${input_name_text} can be up to ${input_lenght} characters`;
+               }
               }
               return null;
             })(),


### PR DESCRIPTION
Problem
-------
The provisioning portal previously required the “code” field to contain *exactly* INPUT_LENGTH characters:

    if (code.length !== input_lenght) { … }

However, the documentation states that INPUT_LENGTH is a *maximum* length.  Any shorter value triggered an HTTP 400 response and the “Invalid input” banner.

Solution
--------
* Changed the JavaScript condition in `provision_html.h` from   `code.length !== input_lenght` to `code.length > input_lenght`. The browser now accepts any non-empty string whose length is **≤ INPUT_LENGTH**.

* Updated the error message to reflect the new behavior:   “should be N characters long” → “can be up to N characters”.