### PR TITLE
remove rogue bracket

### DIFF
--- a/src/internal/provision_html.h
+++ b/src/internal/provision_html.h
@@ -670,7 +670,6 @@ static constexpr const char index_html13[] PROGMEM =
               }
               if (code_listener.value.length > input_lenght) {
                 return `${input_name_text} can be up to ${input_lenght} characters`;
-               }
               }
               return null;
             })(),


### PR DESCRIPTION
An rogue bracket was breaking the client. Fixes #14.